### PR TITLE
Add session closing and confetti improvements

### DIFF
--- a/src/app/game/[sessionId]/GameLayout.tsx
+++ b/src/app/game/[sessionId]/GameLayout.tsx
@@ -4,17 +4,25 @@
 import { ReactNode, useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Logo from "@/components/ui/Logo";
+import dynamic from "next/dynamic";
+import { useGameStore } from "@/store/gameStore";
+
+const Confetti = dynamic(() => import("react-confetti"), { ssr: false });
 
 export default function GameLayout({ children }: { children: ReactNode }) {
   // Estado para detectar la orientación y tamaño
   const [isMobile, setIsMobile] = useState(false);
   const [isTablet, setIsTablet] = useState(false);
+  const showConfetti = useGameStore((state) => state.showConfetti);
+
+  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
     const handleResize = () => {
       const width = window.innerWidth;
       setIsMobile(width < 768);
       setIsTablet(width >= 768 && width <= 1280);
+      setWindowSize({ width, height: window.innerHeight });
     };
 
     handleResize();
@@ -24,6 +32,16 @@ export default function GameLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex flex-col min-h-screen bg-main-gradient relative">
+      {showConfetti && (
+        <Confetti
+          width={windowSize.width}
+          height={windowSize.height}
+          recycle={false}
+          numberOfPieces={500}
+          gravity={0.2}
+          className="pointer-events-none fixed inset-0"
+        />
+      )}
       {/* [modificación] Header compacto y con layout similar al de registro para consistencia */}
       <header className="w-full flex justify-center items-center min-h-[65px] border-b border-white/10 backdrop-blur-sm">
         {/* [modificación] Contenedor con tamaño máximo consistente con el formulario de registro */}

--- a/src/components/admin/SessionsTabContent.tsx
+++ b/src/components/admin/SessionsTabContent.tsx
@@ -1,6 +1,6 @@
 // src/components/admin/SessionsTabContent.tsx
 import { motion } from 'framer-motion';
-import { FiCalendar, FiPlusCircle, FiSettings, FiClock, FiUser, FiPlay } from 'react-icons/fi';
+import { FiCalendar, FiPlusCircle, FiSettings, FiClock, FiUser, FiPlay, FiXCircle } from 'react-icons/fi';
 import Button from '@/components/ui/Button';
 // [modificación] Importar animaciones desde el archivo centralizado
 import { fadeInUp, staggerContainer } from '@/utils/animations';
@@ -8,6 +8,7 @@ import { fadeInUp, staggerContainer } from '@/utils/animations';
 import { useRef, useState } from 'react';
 // [modificación] Importar el store global de navegación
 import { useNavigationStore } from '@/store/navigationStore';
+import { useGameStore } from '@/store/gameStore';
 // [modificación] Importar PlaySession para usar la interfaz directamente
 import { PlaySession } from '@/types';
 
@@ -30,8 +31,10 @@ const SessionsTabContent: React.FC<SessionsTabContentProps> = ({
   const navigationInProgress = useRef(false);
   // [modificación] Estado para seguimiento de cuál sesión está siendo activada
   const [activatingSession, setActivatingSession] = useState<string | null>(null);
+  const [closingSession, setClosingSession] = useState<string | null>(null);
   // [modificación] Acceder al store global de navegación
   const startNavigation = useNavigationStore(state => state.startNavigation);
+  const updateSessionStatus = useGameStore(state => state.updateSessionStatus);
 
   // [modificación] Función para activar la partida usando el overlay global
   const handleActivateGame = (session: PlaySession, e: React.MouseEvent) => {
@@ -47,11 +50,12 @@ const SessionsTabContent: React.FC<SessionsTabContentProps> = ({
     setActivatingSession(session.session_id);
     navigationInProgress.current = true;
     
-    // [modificación] Usar el overlay global para la navegación
+    // Actualizar estado a in_progress
+    updateSessionStatus(session.session_id, 'in_progress');
+
     const targetPath = `/register/${session.session_id}`;
     console.log(`Iniciando navegación con overlay global a: ${targetPath}`);
-    
-    // Iniciar la navegación con overlay global
+
     startNavigation(targetPath, 'Activando sesión de juego...');
     
     // Restablecer el estado local después de un tiempo
@@ -59,6 +63,14 @@ const SessionsTabContent: React.FC<SessionsTabContentProps> = ({
       navigationInProgress.current = false;
       setActivatingSession(null);
     }, 500);
+  };
+
+  const handleCloseSession = async (session: PlaySession, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (closingSession) return;
+    setClosingSession(session.session_id);
+    await updateSessionStatus(session.session_id, 'completed');
+    setClosingSession(null);
   };
 
   // [modificación] Función para obtener clases de estado según el status de la sesión con estilos actualizados
@@ -87,7 +99,7 @@ const SessionsTabContent: React.FC<SessionsTabContentProps> = ({
       case 'player_registered':
         return 'Jugador Registrado';
       case 'in_progress':
-        return 'En Progreso';
+        return 'Activada';
       case 'completed':
         return 'Completado';
       case 'archived':
@@ -204,22 +216,28 @@ const SessionsTabContent: React.FC<SessionsTabContentProps> = ({
                       ) : (
                         <>
                           <FiPlay className="mr-1" size={12} />
-                          Activar
+                          {session.status === 'in_progress' ? 'Activada' : 'Activar'}
                         </>
                       )}
                     </Button>
                     
                     <Button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectSession(session);
-                      }}
+                      onClick={(e) => handleCloseSession(session, e)}
                       variant="custom"
-                      disabled={activatingSession === session.session_id}
-                      className="bg-black/5 hover:bg-black/10 text-slate-800 text-xs py-1.5 px-3 rounded-md shadow-sm flex items-center border border-white/30 transition-colors duration-300"
+                      disabled={closingSession === session.session_id}
+                      className="bg-red-500/80 hover:bg-red-600/90 text-white text-xs py-1.5 px-3 rounded-md shadow-sm flex items-center border border-red-400/50 transition-colors duration-300"
                     >
-                      <FiSettings className="mr-1" size={12} />
-                      Opciones
+                      {closingSession === session.session_id ? (
+                        <>
+                          <span className="w-3 h-3 mr-2 rounded-full bg-black/80 animate-pulse"></span>
+                          Cerrando...
+                        </>
+                      ) : (
+                        <>
+                          <FiXCircle className="mr-1" size={12} />
+                          Cerrar
+                        </>
+                      )}
                     </Button>
                   </div>
                 </div>

--- a/src/components/game/QuestionDisplay.tsx
+++ b/src/components/game/QuestionDisplay.tsx
@@ -2,7 +2,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useGameStore } from '@/store/gameStore';
 import type { Question, AnswerOption } from '@/types';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import Button from '@/components/ui/Button';
 
 interface TimerProps {
@@ -74,15 +74,14 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
     (state) => state.updateCurrentParticipantScore
   );
   const setPrizeFeedback = useGameStore((state) => state.setPrizeFeedback);
+  const setShowConfetti = useGameStore((state) => state.setShowConfetti);
 
   const [selectedAnswer, setSelectedAnswer] = useState<AnswerOption | null>(null);
   const [isAnswered, setIsAnswered] = useState(false);
-  const [showFeedback, setShowFeedback] = useState(false);
 
   useEffect(() => {
     setSelectedAnswer(null);
     setIsAnswered(false);
-    setShowFeedback(false);
   }, [question]);
 
   const handleTimeUp = useCallback(() => {
@@ -103,7 +102,6 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
         prizeName: "",
       });
       
-      setShowFeedback(true);
       setIsAnswered(true);
       setTimeout(() => {
         setGameState('prize');
@@ -116,10 +114,13 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
       if (isAnswered) return;
       setSelectedAnswer(option);
       setIsAnswered(true);
-      setShowFeedback(true);
 
       const correctAnswer = option.correct;
       const prizeWon = correctAnswer ? question.prize : undefined;
+
+      if (correctAnswer) {
+        setShowConfetti(true);
+      }
       
       const correctOption = question.options.find(o => o.correct);
 
@@ -143,12 +144,13 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
       }, 2500);
     },
     [
-      isAnswered, 
-      question, 
-      currentParticipant, 
-      updateCurrentParticipantScore, 
+      isAnswered,
+      question,
+      currentParticipant,
+      updateCurrentParticipantScore,
       setGameState,
-      setPrizeFeedback
+      setPrizeFeedback,
+      setShowConfetti
     ]
   );
 
@@ -236,25 +238,7 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
         ))}
       </div>
 
-      <div className="mt-6 pt-4 border-t border-white/20 w-full">
-        <AnimatePresence mode="wait">
-          {showFeedback && isAnswered && (
-            <motion.div
-              key="feedback"
-              initial={{ opacity: 0, y: 15 }}
-              animate={{ opacity: 1, y: 0, transition: { delay: 0.1, duration: 0.3 } }}
-              exit={{ opacity: 0, y: -10, transition: { duration: 0.2 } }}
-              className="text-center"
-            >
-              {selectedAnswer?.correct ? (
-                <p className="text-verde-salud font-marineBold text-xl md:text-2xl">¡Correcto!</p>
-              ) : (
-                <p className="text-red-400 font-marineBold text-xl md:text-2xl">Incorrecto</p>
-              )}
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
+      <div className="mt-6 pt-4 border-t border-white/20 w-full"></div>
     </motion.div>
   );
 }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -27,6 +27,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
     prizeName: "",
   },
 
+  // Estado global para mostrar confeti
+  showConfetti: false,
+
   // Estado del administrador
   adminUser: null,
   adminState: {
@@ -134,6 +137,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   // [modificación] Funciones para gestionar el feedback del premio
   setPrizeFeedback: (feedback) => set({ prizeFeedback: feedback }),
+
+  setShowConfetti: (value: boolean) => set({ showConfetti: value }),
   
   resetPrizeFeedback: () => set({ 
     prizeFeedback: { 
@@ -151,11 +156,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
     currentQuestion: null,
     lastSpinResultIndex: null,
     gameSession: null,
-    prizeFeedback: { 
-      answeredCorrectly: null, 
-      explanation: "", 
-      correctOption: "", 
-      prizeName: "" 
+    showConfetti: false,
+    prizeFeedback: {
+      answeredCorrectly: null,
+      explanation: "",
+      correctOption: "",
+      prizeName: ""
     },
     // No se limpian las 'questions' si son genéricas
   }),
@@ -170,10 +176,11 @@ export const useGameStore = create<GameStore>((set, get) => ({
     currentPlay: null,
     gameSession: null,
     questions: [],
-    prizeFeedback: { 
-      answeredCorrectly: null, 
-      explanation: "", 
-      correctOption: "", 
+    showConfetti: false,
+    prizeFeedback: {
+      answeredCorrectly: null,
+      explanation: "",
+      correctOption: "",
       prizeName: "" 
     },
   }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,7 @@ export interface GameStore {
   gameSession: PlaySession | null;
   adminState: AdminState;
   prizeFeedback: PrizeFeedback;
+  showConfetti: boolean;
   setGameState: (state: GameState) => void;
   addParticipant: (participantData: Omit<Participant, 'id' | 'timestamp'>) => void;
   startPlaySession: (
@@ -122,6 +123,7 @@ export interface GameStore {
   resetCurrentGameData: () => void;
   setPrizeFeedback: (feedback: PrizeFeedback) => void;
   resetPrizeFeedback: () => void;
+  setShowConfetti: (value: boolean) => void;
   setAdminUser: (adminData: AdminUser | null) => void;
   fetchGameSessions: () => Promise<PlaySession[]>;
   setGameSession: (sessionData: PlaySession | null) => void;


### PR DESCRIPTION
## Summary
- allow admin to close sessions from list
- mark sessions as activated and update status on activation
- trigger confetti globally from question to prize modal
- reset session when finishing game
- remove correctness text from questions

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*