### PR TITLE
Add session closing and confetti improvements

### DIFF
--- a/src/app/game/[sessionId]/GameLayout.tsx
+++ b/src/app/game/[sessionId]/GameLayout.tsx
@@ -4,17 +4,25 @@
 import { ReactNode, useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Logo from "@/components/ui/Logo";
+import dynamic from "next/dynamic";
+import { useGameStore } from "@/store/gameStore";
+
+const Confetti = dynamic(() => import("react-confetti"), { ssr: false });
 
 export default function GameLayout({ children }: { children: ReactNode }) {
   // Estado para detectar la orientación y tamaño
   const [isMobile, setIsMobile] = useState(false);
   const [isTablet, setIsTablet] = useState(false);
+  const showConfetti = useGameStore((state) => state.showConfetti);
+
+  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
     const handleResize = () => {
       const width = window.innerWidth;
       setIsMobile(width < 768);
       setIsTablet(width >= 768 && width <= 1280);
+      setWindowSize({ width, height: window.innerHeight });
     };
 
     handleResize();
@@ -24,6 +32,16 @@ export default function GameLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex flex-col min-h-screen bg-main-gradient relative">
+      {showConfetti && (
+        <Confetti
+          width={windowSize.width}
+          height={windowSize.height}
+          recycle={false}
+          numberOfPieces={500}
+          gravity={0.2}
+          className="pointer-events-none fixed inset-0"
+        />
+      )}
       {/* [modificación] Header compacto y con layout similar al de registro para consistencia */}
       <header className="w-full flex justify-center items-center min-h-[65px] border-b border-white/10 backdrop-blur-sm">
         {/* [modificación] Contenedor con tamaño máximo consistente con el formulario de registro */}

--- a/src/components/admin/SessionControls.tsx
+++ b/src/components/admin/SessionControls.tsx
@@ -149,7 +149,7 @@ export default function SessionControls({ session, onSessionUpdate }: SessionCon
           </button>
           
           <button
-            onClick={() => updateSessionStatus('in_progress')}
+            onClick={() => updateSessionStatus('playing')}
             disabled={isLoading || !isPlayerRegistered(session)}
             className="bg-yellow-600 hover:bg-yellow-700 text-white py-2 px-3 rounded-md text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/src/components/game/PrizeModal.tsx
+++ b/src/components/game/PrizeModal.tsx
@@ -4,24 +4,18 @@ import { motion } from "framer-motion";
 import Button from "@/components/ui/Button";
 import Image from "next/image";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
-import { useState, useEffect } from "react";
-import dynamic from "next/dynamic";
-
-// Importación dinámica para evitar problemas de SSR con window
-const Confetti = dynamic(() => import("react-confetti"), { ssr: false });
+import { useEffect, useState } from "react";
 
 export default function PrizeModal() {
   const setGameState = useGameStore((state) => state.setGameState);
   const resetCurrentGame = useGameStore((state) => state.resetCurrentGame);
   const currentParticipant = useGameStore((state) => state.currentParticipant);
-  const setCurrentParticipant = useGameStore(
-    (state) => state.setCurrentParticipant
-  );
+  const setCurrentParticipant = useGameStore((state) => state.setCurrentParticipant);
   const prizeFeedback = useGameStore((state) => state.prizeFeedback);
   const resetPrizeFeedback = useGameStore((state) => state.resetPrizeFeedback);
+  const showConfetti = useGameStore((state) => state.showConfetti);
+  const setShowConfetti = useGameStore((state) => state.setShowConfetti);
 
-  // Estado para confeti
-  const [showConfetti, setShowConfetti] = useState(false);
   const [windowSize, setWindowSize] = useState({
     width: typeof window !== "undefined" ? window.innerWidth : 0,
     height: typeof window !== "undefined" ? window.innerHeight : 0,
@@ -37,7 +31,6 @@ export default function PrizeModal() {
 
   // Efecto para gestionar el confeti
   useEffect(() => {
-    // Actualizar tamaño de ventana para el confeti
     const handleResize = () => {
       setWindowSize({
         width: window.innerWidth,
@@ -46,33 +39,46 @@ export default function PrizeModal() {
     };
     window.addEventListener("resize", handleResize);
 
-    // Mostrar confeti cuando responde correctamente
     if (answeredCorrectly) {
       setShowConfetti(true);
-      // Detener confeti después de 5 segundos
-      const timer = setTimeout(() => {
-        setShowConfetti(false);
-      }, 5000);
-      return () => {
-        clearTimeout(timer);
-        window.removeEventListener("resize", handleResize);
-      };
     }
-    return () => window.removeEventListener("resize", handleResize);
-  }, [answeredCorrectly]);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [answeredCorrectly, setShowConfetti]);
 
-  const handlePlayAgain = () => {
-    resetCurrentGame();
-    setCurrentParticipant(null);
-    resetPrizeFeedback();
-    setGameState("register"); // Va directo al registro para el próximo participante
+  const gameSession = useGameStore((state) => state.gameSession);
+
+  const resetSessionForNextPlayer = async () => {
+    if (gameSession) {
+      try {
+        await fetch('/api/admin/sessions/reset-player', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: gameSession.session_id }),
+        });
+      } catch (err) {
+        console.error('Error resetting session:', err);
+      }
+    }
   };
 
-  const handleGoHome = () => {
+  const handlePlayAgain = async () => {
+    await resetSessionForNextPlayer();
     resetCurrentGame();
     setCurrentParticipant(null);
     resetPrizeFeedback();
-    setGameState("screensaver"); // Vuelve a la pantalla de inicio/reposo
+    setShowConfetti(false);
+    setGameState("register");
+  };
+
+  const handleGoHome = async () => {
+    await resetSessionForNextPlayer();
+    resetCurrentGame();
+    setCurrentParticipant(null);
+    resetPrizeFeedback();
+    setShowConfetti(false);
+    setGameState("screensaver");
   };
 
   if (answeredCorrectly === null) {
@@ -131,24 +137,7 @@ export default function PrizeModal() {
       aria-modal="true"
       role="dialog"
     >
-      {/* Confetti cuando hay respuesta correcta */}
-      {showConfetti && answeredCorrectly && (
-        <Confetti
-          width={windowSize.width}
-          height={windowSize.height}
-          recycle={false}
-          numberOfPieces={500}
-          gravity={0.2}
-          colors={[
-            "#FFC107",
-            "#FF9800",
-            "#FF5722",
-            "#4CAF50",
-            "#2196F3",
-            "#9C27B0",
-          ]}
-        />
-      )}
+
 
       <motion.div
         key="prizeModalContent"

--- a/src/components/game/QuestionDisplay.tsx
+++ b/src/components/game/QuestionDisplay.tsx
@@ -2,7 +2,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useGameStore } from '@/store/gameStore';
 import type { Question, AnswerOption } from '@/types';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import Button from '@/components/ui/Button';
 
 interface TimerProps {
@@ -74,15 +74,14 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
     (state) => state.updateCurrentParticipantScore
   );
   const setPrizeFeedback = useGameStore((state) => state.setPrizeFeedback);
+  const setShowConfetti = useGameStore((state) => state.setShowConfetti);
 
   const [selectedAnswer, setSelectedAnswer] = useState<AnswerOption | null>(null);
   const [isAnswered, setIsAnswered] = useState(false);
-  const [showFeedback, setShowFeedback] = useState(false);
 
   useEffect(() => {
     setSelectedAnswer(null);
     setIsAnswered(false);
-    setShowFeedback(false);
   }, [question]);
 
   const handleTimeUp = useCallback(() => {
@@ -103,7 +102,6 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
         prizeName: "",
       });
       
-      setShowFeedback(true);
       setIsAnswered(true);
       setTimeout(() => {
         setGameState('prize');
@@ -116,10 +114,13 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
       if (isAnswered) return;
       setSelectedAnswer(option);
       setIsAnswered(true);
-      setShowFeedback(true);
 
       const correctAnswer = option.correct;
       const prizeWon = correctAnswer ? question.prize : undefined;
+
+      if (correctAnswer) {
+        setShowConfetti(true);
+      }
       
       const correctOption = question.options.find(o => o.correct);
 
@@ -143,12 +144,13 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
       }, 2500);
     },
     [
-      isAnswered, 
-      question, 
-      currentParticipant, 
-      updateCurrentParticipantScore, 
+      isAnswered,
+      question,
+      currentParticipant,
+      updateCurrentParticipantScore,
       setGameState,
-      setPrizeFeedback
+      setPrizeFeedback,
+      setShowConfetti
     ]
   );
 
@@ -236,25 +238,7 @@ export default function QuestionDisplay({ question }: QuestionDisplayProps) {
         ))}
       </div>
 
-      <div className="mt-6 pt-4 border-t border-white/20 w-full">
-        <AnimatePresence mode="wait">
-          {showFeedback && isAnswered && (
-            <motion.div
-              key="feedback"
-              initial={{ opacity: 0, y: 15 }}
-              animate={{ opacity: 1, y: 0, transition: { delay: 0.1, duration: 0.3 } }}
-              exit={{ opacity: 0, y: -10, transition: { duration: 0.2 } }}
-              className="text-center"
-            >
-              {selectedAnswer?.correct ? (
-                <p className="text-verde-salud font-marineBold text-xl md:text-2xl">¡Correcto!</p>
-              ) : (
-                <p className="text-red-400 font-marineBold text-xl md:text-2xl">Incorrecto</p>
-              )}
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
+      <div className="mt-6 pt-4 border-t border-white/20 w-full"></div>
     </motion.div>
   );
 }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -27,6 +27,9 @@ export const useGameStore = create<GameStore>((set, get) => ({
     prizeName: "",
   },
 
+  // Estado global para mostrar confeti
+  showConfetti: false,
+
   // Estado del administrador
   adminUser: null,
   adminState: {
@@ -134,6 +137,8 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   // [modificación] Funciones para gestionar el feedback del premio
   setPrizeFeedback: (feedback) => set({ prizeFeedback: feedback }),
+
+  setShowConfetti: (value: boolean) => set({ showConfetti: value }),
   
   resetPrizeFeedback: () => set({ 
     prizeFeedback: { 
@@ -151,11 +156,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
     currentQuestion: null,
     lastSpinResultIndex: null,
     gameSession: null,
-    prizeFeedback: { 
-      answeredCorrectly: null, 
-      explanation: "", 
-      correctOption: "", 
-      prizeName: "" 
+    showConfetti: false,
+    prizeFeedback: {
+      answeredCorrectly: null,
+      explanation: "",
+      correctOption: "",
+      prizeName: ""
     },
     // No se limpian las 'questions' si son genéricas
   }),
@@ -170,10 +176,11 @@ export const useGameStore = create<GameStore>((set, get) => ({
     currentPlay: null,
     gameSession: null,
     questions: [],
-    prizeFeedback: { 
-      answeredCorrectly: null, 
-      explanation: "", 
-      correctOption: "", 
+    showConfetti: false,
+    prizeFeedback: {
+      answeredCorrectly: null,
+      explanation: "",
+      correctOption: "",
       prizeName: "" 
     },
   }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,7 +34,7 @@ export interface PlaySession {
   id: string;
   session_id: string;
   admin_id: string;
-  status: 'pending_player_registration' | 'player_registered' | 'in_progress' | 'completed' | 'archived';
+  status: 'pending_player_registration' | 'player_registered' | 'playing' | 'completed' | 'archived';
   nombre?: string;
   apellido?: string;
   email?: string;
@@ -106,6 +106,7 @@ export interface GameStore {
   gameSession: PlaySession | null;
   adminState: AdminState;
   prizeFeedback: PrizeFeedback;
+  showConfetti: boolean;
   setGameState: (state: GameState) => void;
   addParticipant: (participantData: Omit<Participant, 'id' | 'timestamp'>) => void;
   startPlaySession: (
@@ -122,6 +123,7 @@ export interface GameStore {
   resetCurrentGameData: () => void;
   setPrizeFeedback: (feedback: PrizeFeedback) => void;
   resetPrizeFeedback: () => void;
+  setShowConfetti: (value: boolean) => void;
   setAdminUser: (adminData: AdminUser | null) => void;
   fetchGameSessions: () => Promise<PlaySession[]>;
   setGameSession: (sessionData: PlaySession | null) => void;

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -24,7 +24,7 @@ export function isPlayerRegistered(session: PlaySession | null): boolean {
  * @returns true si la sesión está en progreso
  */
 export function isSessionInProgress(session: PlaySession | null): boolean {
-  return !!(session && session.status === 'in_progress');
+  return !!(session && session.status === 'playing');
 }
 
 /**
@@ -43,9 +43,9 @@ export function isSessionPendingRegistration(session: PlaySession | null): boole
  */
 export function isSessionPlayable(session: PlaySession | null): boolean {
   return !!(
-    session && 
-    (session.status === 'player_registered' || session.status === 'in_progress') &&
+    session &&
+    (session.status === 'player_registered' || session.status === 'playing') &&
     session.nombre &&
     session.email
   );
-} 
+}


### PR DESCRIPTION
## Summary
- allow admin to close sessions from list
- mark sessions as activated and update status on activation
- trigger confetti globally from question to prize modal
- reset session when finishing game
- remove correctness text from questions
- fix session status names and missing import

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
