### PR TITLE
Fix unused variables in admin and game components

### DIFF
--- a/src/components/admin/SessionsTabContent.tsx
+++ b/src/components/admin/SessionsTabContent.tsx
@@ -1,6 +1,6 @@
 // src/components/admin/SessionsTabContent.tsx
 import { motion } from 'framer-motion';
-import { FiCalendar, FiPlusCircle, FiSettings, FiClock, FiUser, FiPlay, FiXCircle } from 'react-icons/fi';
+import { FiCalendar, FiPlusCircle, FiClock, FiUser, FiPlay, FiXCircle } from 'react-icons/fi';
 import Button from '@/components/ui/Button';
 // [modificación] Importar animaciones desde el archivo centralizado
 import { fadeInUp, staggerContainer } from '@/utils/animations';
@@ -14,15 +14,13 @@ import { PlaySession } from '@/types';
 
 interface SessionsTabContentProps {
   activeSessions: PlaySession[];
-  onSelectSession: (session: PlaySession) => void;
   onCreateNewSession: () => void;
-  isLoadingCreation: boolean; 
+  isLoadingCreation: boolean;
   isLoadingList: boolean;
 }
 
 const SessionsTabContent: React.FC<SessionsTabContentProps> = ({
   activeSessions,
-  onSelectSession,
   onCreateNewSession,
   isLoadingCreation,
   isLoadingList,

--- a/src/components/game/PrizeModal.tsx
+++ b/src/components/game/PrizeModal.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 import Button from "@/components/ui/Button";
 import Image from "next/image";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export default function PrizeModal() {
   const setGameState = useGameStore((state) => state.setGameState);
@@ -13,13 +13,7 @@ export default function PrizeModal() {
   const setCurrentParticipant = useGameStore((state) => state.setCurrentParticipant);
   const prizeFeedback = useGameStore((state) => state.prizeFeedback);
   const resetPrizeFeedback = useGameStore((state) => state.resetPrizeFeedback);
-  const showConfetti = useGameStore((state) => state.showConfetti);
   const setShowConfetti = useGameStore((state) => state.setShowConfetti);
-
-  const [windowSize, setWindowSize] = useState({
-    width: typeof window !== "undefined" ? window.innerWidth : 0,
-    height: typeof window !== "undefined" ? window.innerHeight : 0,
-  });
 
   const { answeredCorrectly, explanation, correctOption, prizeName } =
     prizeFeedback;
@@ -29,22 +23,11 @@ export default function PrizeModal() {
     ? `/images/premios/${prizeName.replace(/\s+/g, "-")}.png`
     : null;
 
-  // Efecto para gestionar el confeti
+  // Efecto para mostrar confeti cuando la respuesta es correcta
   useEffect(() => {
-    const handleResize = () => {
-      setWindowSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    };
-    window.addEventListener("resize", handleResize);
-
     if (answeredCorrectly) {
       setShowConfetti(true);
     }
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
   }, [answeredCorrectly, setShowConfetti]);
 
   const gameSession = useGameStore((state) => state.gameSession);


### PR DESCRIPTION
## Summary
- remove unused `FiSettings` icon and onSelectSession prop from `SessionsTabContent`
- clean up unused state and effect in `PrizeModal`

## Testing
- `npm run lint` *(fails: `next` not found)*