### PR TITLE
Improve prize flow and responsive modal

### DIFF
--- a/src/components/game/PrizeModal.tsx
+++ b/src/components/game/PrizeModal.tsx
@@ -5,6 +5,7 @@ import Button from "@/components/ui/Button";
 import Image from "next/image";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 export default function PrizeModal() {
   const setGameState = useGameStore((state) => state.setGameState);
@@ -13,6 +14,8 @@ export default function PrizeModal() {
   const setCurrentParticipant = useGameStore((state) => state.setCurrentParticipant);
   const prizeFeedback = useGameStore((state) => state.prizeFeedback);
   const resetPrizeFeedback = useGameStore((state) => state.resetPrizeFeedback);
+  const gameSession = useGameStore((state) => state.gameSession);
+  const router = useRouter();
 
   // Estado para confeti
   const [showConfetti, setShowConfetti] = useState(false);
@@ -64,11 +67,13 @@ export default function PrizeModal() {
   };
 
   const handleGoHome = async () => {
+    const sessionId = gameSession?.session_id;
     resetCurrentGame();
     setCurrentParticipant(null);
     resetPrizeFeedback();
     setShowConfetti(false);
-    setGameState("screensaver");
+    setGameState("register");
+    if (sessionId) router.push(`/register/${sessionId}`);
   };
 
   if (answeredCorrectly === null) {

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -26,7 +26,7 @@ export default function Modal({ isOpen, onClose, children, title }: ModalProps) 
             initial={{ scale: 0.9, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             exit={{ scale: 0.9, opacity: 0, y: 20 }}
-            className="bg-white/10 backdrop-blur-sm p-6 rounded-lg shadow-xl w-full max-w-md relative border border-white/30 text-white"
+            className="bg-white/10 backdrop-blur-sm w-full max-w-sm sm:max-w-md lg:max-w-xl p-4 sm:p-6 lg:p-8 rounded-lg shadow-xl relative border border-white/30 text-white"
             onClick={(e) => e.stopPropagation()} // Evita que el clic dentro del modal lo cierre
           >
             {title && (


### PR DESCRIPTION
## Summary
- make generic Modal responsive across breakpoints
- redirect "Volver al Inicio" button in prize modal to registration form

## Testing
- `npm run lint` *(fails: `next` not found)*