### PR TITLE
Add touch-optimized tablet and TV views

### DIFF
--- a/src/app/game/[sessionId]/GameLayout.tsx
+++ b/src/app/game/[sessionId]/GameLayout.tsx
@@ -13,6 +13,7 @@ export default function GameLayout({ children }: { children: ReactNode }) {
   // Estado para detectar la orientación y tamaño
   const [isMobile, setIsMobile] = useState(false);
   const [isTablet, setIsTablet] = useState(false);
+  const [isTV, setIsTV] = useState(false);
   const showConfetti = useGameStore((state) => state.showConfetti);
 
   const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
@@ -22,6 +23,7 @@ export default function GameLayout({ children }: { children: ReactNode }) {
       const width = window.innerWidth;
       setIsMobile(width < 768);
       setIsTablet(width >= 768 && width <= 1280);
+      setIsTV(width >= 1920);
       setWindowSize({ width, height: window.innerHeight });
     };
 
@@ -45,7 +47,7 @@ export default function GameLayout({ children }: { children: ReactNode }) {
       {/* [modificación] Header compacto y con layout similar al de registro para consistencia */}
       <header className="w-full flex justify-center items-center min-h-[65px] border-b border-white/10 backdrop-blur-sm">
         {/* [modificación] Contenedor con tamaño máximo consistente con el formulario de registro */}
-        <div className={`${isMobile ? 'max-w-[150px]' : isTablet ? 'max-w-[165px]' : 'max-w-[200px]'} w-full flex justify-center items-center`}>
+        <div className={`${isMobile ? 'max-w-[150px]' : isTablet ? 'max-w-[165px]' : isTV ? 'max-w-[220px]' : 'max-w-[200px]'} w-full flex justify-center items-center`}>
           <Logo
             size="auto"
             animated={true}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -537,6 +537,30 @@ body {
   }
 }
 
+/* Optimizaciones para TV táctil de gran tamaño */
+
+@media (min-width: 1921px) {
+  .text-touch-xl {
+    font-size: 2.5rem; /* 40px */
+  }
+
+  .text-touch-lg {
+    font-size: 2rem; /* 32px */
+  }
+
+  .btn-touch {
+    min-height: 72px;
+
+    min-width: 72px;
+
+    padding: 20px 40px;
+  }
+
+  .wheel-canvas {
+    max-height: 90vh;
+  }
+}
+
 /* [modificación] Para orientación landscape en dispositivos táctiles */
 
 @media (orientation: landscape) and (max-height: 768px) {

--- a/src/components/game/RegistrationForm.tsx
+++ b/src/components/game/RegistrationForm.tsx
@@ -236,15 +236,16 @@ export default function RegistrationForm({
     typeof window !== "undefined" &&
     window.innerWidth > 500 &&
     window.innerWidth <= 768;
+  const isTV = typeof window !== "undefined" && window.innerWidth >= 1920;
 
   return (
     <div
-      className={`flex flex-col items-center justify-between w-full mx-auto 
+      className={`flex flex-col items-center justify-between w-full mx-auto
         p-4 sm:p-5 md:p-6 rounded-2xl bg-slate-900/20 ${textOnDarkBase} shadow-2xl
-        ${isMobile ? "max-w-full" : isTablet ? "max-w-[95%]" : "max-w-lg"}`}
+        ${isMobile ? "max-w-full" : isTablet ? "max-w-[95%]" : isTV ? "max-w-[800px]" : "max-w-lg"}`}
       style={{
         minHeight: "auto",
-        maxHeight: isMobile ? "80vh" : isTablet ? "75vh" : "70vh",
+        maxHeight: isMobile ? "80vh" : isTablet ? "75vh" : isTV ? "65vh" : "70vh",
       }}
     >
       <motion.div

--- a/src/components/game/RouletteWheel.tsx
+++ b/src/components/game/RouletteWheel.tsx
@@ -93,6 +93,7 @@ const RouletteWheel = forwardRef<{ spin: () => void }, RouletteWheelProps>(
     const [isLandscape, setIsLandscape] = useState(false);
     const [isTablet, setIsTablet] = useState(false);
     const [isMobile, setIsMobile] = useState(false);
+    const [isTV, setIsTV] = useState(false);
 
     const [isSpinning, setIsSpinning] = useState(false);
     const [currentAngle, setCurrentAngle] = useState(0);
@@ -123,6 +124,7 @@ const RouletteWheel = forwardRef<{ spin: () => void }, RouletteWheelProps>(
         setIsLandscape(width > height);
         setIsTablet(width >= 768 && width <= 1280);
         setIsMobile(width < 768);
+        setIsTV(width >= 1920);
       };
       handleDeviceDetection();
       window.addEventListener("resize", handleDeviceDetection);
@@ -167,6 +169,8 @@ const RouletteWheel = forwardRef<{ spin: () => void }, RouletteWheelProps>(
           size = Math.max(220, Math.min(size, 400));
         } else if (isTablet) {
           size = Math.max(320, Math.min(size, 520));
+        } else if (isTV) {
+          size = Math.max(700, Math.min(size, 900));
         } else {
           size = Math.max(380, Math.min(size, 640));
         }
@@ -192,6 +196,7 @@ const RouletteWheel = forwardRef<{ spin: () => void }, RouletteWheelProps>(
       isSpinning,
       isLandscape,
       isTablet,
+      isTV,
       isMobile,
     ]);
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,10 @@ const config: Config = {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    screens: {
+      tablet: { min: "768px", max: "1280px" },
+      tv: { min: "1920px" },
+    },
     extend: {
       colors: {
         "azul-intenso": "#192A6E",


### PR DESCRIPTION
## Summary
- add custom `tablet` and `tv` screens in Tailwind config
- detect TV screens across components
- tune layout sizing in registration form and game layout
- adjust roulette wheel size for large touch TV
- include CSS rules for large TV touch devices

## Testing
- `npm run lint`
- `npm run build`